### PR TITLE
game.1.3.11.mod.13

### DIFF
--- a/.metadata/metadata.json
+++ b/.metadata/metadata.json
@@ -1,7 +1,7 @@
 {
-  "name" : "TEST Ars Belli Mod",
+  "name" : "Ars Belli Mod",
   "id" : "arsbelli.arsbellimultiplayermod",
-  "version" : "game.1.3.11.mod.12",
+  "version" : "game.1.3.11.mod.13",
   "game_id" : "eu5",
   "picture" : "thumbnail.png",
   "supported_game_version" : "1.3.*",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,41 @@
 Player-facing changes per release, newest first. For the full current state of every
 mod system (not just what changed), see `changes.txt`.
 
+## game.1.3.11.mod.13
+
+Since game.1.3.11.mod.12 → game.1.3.11.mod.13:
+
+> One large content merge. The starting setup is the headline: the world outside Europe is
+> built out into playable countries with their own advances, and several nations are reworked.
+
+### Pops & Setup
+
+- **India and China** have dozens of playable tags, many with their own advancement sets based
+  on the countries' original EU4 national ideas
+- **Japan is fully playable** with over 30 clans and a functional Shinto religion, loosely based
+  on the Sengoku Jidai period
+- **West and East Africa expanded**: several tribal societies of pops are playable as settled
+  countries, with their own advances
+- **The Middle East is reworked** around a much less dominant Mamluks, with many formable tags in
+  Arabia and Persia — Hejaz, Najd, Fars, Khorasan and more
+- **Central Asia** gets many playable tags, hordes with proper advancement sets, and formables
+  such as Bukhara, Greater Khorasan and a reworked Mongol Empire
+- **Europe** reworked so HRE minors are more viable and France and Castile less overbearing, with
+  many small tweaks to the starting balance
+
+### Nation Reworks & Unique Content
+
+- **Hordes reworked**: steppe-horde advances and government content, an emphasis on raiding, and
+  unavoidable nerfs to horse archers
+- **Venice** and the rest of Italy get small adjustments, with their own advances and unit types
+- new unique unit types by age and region (knights, Byzantine units, bedouin cavalry, Indian and
+  Italian units) instead of flat numerical buffs for countries that need a leg up
+- regional advancement sets across China, India, Indochina, Indonesia, Anatolia, the Caucasus,
+  Ruthenia, Arabia, Persia, Central Asia, Tibet, Xinjiang, the Urals, Mongolia, Madagascar and
+  Africa
+- new estate privileges, government reforms (general, China, Europe, India), levies and culture
+  buildings
+
 ## game.1.3.11.mod.12
 
 Since game.1.3.11.mod.11 → game.1.3.11.mod.12:

--- a/changes.txt
+++ b/changes.txt
@@ -139,6 +139,20 @@ new "Dismiss Head of Cabinet" character interaction: returns your current Head t
 
 updated for game 1.2
 pop adjustments across Asia: Timurid, Delhi, Khmer, Ayutthaya, Ming (middle kingdom), and the Lordship of Pale
+India and China have dozens of playable tags, many with their own advancement sets based on the countries' original EU4 national ideas
+Japan is fully playable with over 30 clans and a functional Shinto religion, loosely based on the Sengoku Jidai period
+West and East Africa expanded: several tribal societies of pops are playable as settled countries with their own advances
+the Middle East is reworked around a much less dominant Mamluks, with many formable tags in Arabia and Persia (Hejaz, Najd, Fars, Khorasan and more)
+Central Asia gets many playable tags, hordes with proper advancement sets, and formables such as Bukhara, Greater Khorasan and a reworked Mongol Empire
+Europe reworked so HRE minors are more viable and France and Castile less overbearing, with many small tweaks to the starting balance
+
+# Nation Reworks & Unique Content:
+
+hordes reworked: steppe-horde advances and government content, an emphasis on raiding, and unavoidable nerfs to horse archers
+Venice and the rest of Italy small adjustments, with their own advances and unit types
+new unique unit types by age and region (knights, Byzantine units, bedouin cavalry, Indian and Italian units) instead of flat numerical buffs for countries that need a leg up
+regional advancement sets across China, India, Indochina, Indonesia, Anatolia, the Caucasus, Ruthenia, Arabia, Persia, Central Asia, Tibet, Xinjiang, the Urals, Mongolia, Madagascar and Africa
+new estate privileges, government reforms (general, China, Europe, India), levies and culture buildings
 
 # Patch Compatibility:
 


### PR DESCRIPTION
Release cut for **game.1.3.11.mod.13**. Tag and GitHub release are already published from this branch; this PR folds the two commits into `main`, which is protected against direct pushes.

- `3936ee4` — changelog entry (`CHANGELOG.md` + `changes.txt`) for the mod.13 content merge
- `89c2763` — version bump to `game.1.3.11.mod.13` in `.metadata/metadata.json`

Release: https://github.com/Ars-Belli/Ars-Belli-Mod/releases/tag/game.1.3.11.mod.13

🤖 Generated with [Claude Code](https://claude.com/claude-code)