### PR TITLE
Fix culture bridges and disable Conquistadors

### DIFF
--- a/changes.txt
+++ b/changes.txt
@@ -89,6 +89,15 @@ the HRE Emperor no longer gets the vanilla Enforce Peace and Intervene in War, a
 
 offering your own armies as mercenaries is removed: the "Become Mercenary" button in the army builder, which opened the "Set Up The Mercenary Contract" window, is gone, and the "Make available for hire" unit action no longer shows anywhere it used to render — the single-unit action bar, a multi-unit selection, the pinned quick-action row, and the right-click unit menu — nor is it reachable by the AI or by delegation automation. Renting your own regiments out put the mercenary modifiers on the hirer while the owner kept drawing the full hire price, which between two players was a gold transfer that paid a profit. Delisting a unit already on the market still works
 
+# Cultures:
+
+Indian cultures that also belonged to the Tibeto-Burman group now keep their Indian membership instead; Newar also remains Nepali. Yi and Bai are Tibeto-Burman only, the four Japanese cultures are Japanese only, Vietnamese and Muong are Austroasiatic only, Norn is Scottish only, and the Korean, Tamna and She cultures no longer belong to a culture group
+the cultures removed from the Confucian group keep access to the Confucian School and Academy advances, the Confucian School building, Imperial Examinations, Petty Bureaucracy and Scholar Officials through an explicit compatibility list
+
+# Conquistadors:
+
+creating Conquistador countries is disabled for players, the AI and delegation automation to prevent their automatic occupation mechanic from bypassing normal warfare. The Cortés event still provides him as a normal general, and the Conquistador reform is neutralized for existing or queued cases
+
 # Economy:
 
 destroy market price capped at 10

--- a/in_game/common/advances/ars_belli_confucian_access.txt
+++ b/in_game/common/advances/ars_belli_confucian_access.txt
@@ -1,0 +1,46 @@
+﻿REPLACE:confucian_school_advance = {
+	age = age_1_traditions
+
+	requires = scriptorium_advance
+	potential = {
+		OR =  {
+			culture = { ars_belli_has_confucian_culture_access = yes }
+			religion = religion:sanjiao
+			any_international_organizations_member_of = {
+				international_organization_type = international_organization_type:sect
+				international_organization_has_policy = policy:confucianism_policy
+			}
+			custom_tooltip = {
+				text = has_neo_confucianism_tt
+				has_variable = has_neo_confucianism
+			}
+			is_member_of_international_organization = international_organization:middle_kingdom
+		}
+	}
+
+	unlock_building = confucian_school
+}
+
+REPLACE:confucian_academy_advance = {
+	age = age_2_renaissance
+
+	requires = government_size_renaissance
+
+	potential = {
+		OR =  {
+			culture = { ars_belli_has_confucian_culture_access = yes }
+			religion = religion:sanjiao
+			any_international_organizations_member_of = {
+				international_organization_type = international_organization_type:sect
+				international_organization_has_policy = policy:confucianism_policy
+			}
+			custom_tooltip = {
+				text = has_neo_confucianism_tt
+				has_variable = has_neo_confucianism
+			}
+			is_member_of_international_organization = international_organization:middle_kingdom
+		}
+	}
+
+	unlock_building = confucian_academy
+}

--- a/in_game/common/advances/ars_belli_no_conquistadors.txt
+++ b/in_game/common/advances/ars_belli_no_conquistadors.txt
@@ -1,0 +1,10 @@
+﻿REPLACE:conquistador_advance = {
+	icon = new_world_advance
+	age = age_3_discovery
+
+	potential = {
+		always = no
+	}
+
+	requires = colonial_charters
+}

--- a/in_game/common/building_types/ars_belli_confucian_access.txt
+++ b/in_game/common/building_types/ars_belli_confucian_access.txt
@@ -1,0 +1,50 @@
+﻿REPLACE:confucian_school = {
+	audio_tier = 1
+	is_special = yes
+	is_foreign = no
+	max_levels = 1
+	pop_type = nobles
+
+	employment_size = noble_cultural_employment
+	category = cultural_category
+
+	AI_ignore_available_worker_flag = yes #since we may build this to increase pop promotion we don't want lack of workers to block it
+
+	rural_settlement = no
+	town = yes
+	city = yes
+	megalopolis = yes
+
+	build_time = cultural_building_time
+
+	country_potential = {
+		OR = {
+			culture = { ars_belli_has_confucian_culture_access = yes }
+			religion ?= religion:sanjiao
+			any_international_organizations_member_of = {
+				international_organization_type = international_organization_type:sect
+				international_organization_has_policy = policy:confucianism_policy
+			}
+			custom_tooltip = {
+				text = has_neo_confucianism_tt
+				has_variable = has_neo_confucianism
+			}
+			is_member_of_international_organization = international_organization:middle_kingdom
+		}
+	}
+
+	possible_production_methods = {
+		confucian_school_maintenance
+	}
+
+	construction_demand = school_construction
+
+	modifier = {
+		local_max_literacy = 5
+		local_pop_promotion_speed = 0.001
+		local_institution_growth_modifier = 0.25
+	}
+	capital_country_modifier = {
+		monthly_towards_sinicized = societal_value_tiny_monthly_move
+	}
+}

--- a/in_game/common/cultures/abm_east_asia_cultures.txt
+++ b/in_game/common/cultures/abm_east_asia_cultures.txt
@@ -24,11 +24,10 @@ REPLACE:yi_culture = {
 	tags = { east_asian_gfx }
 
 	opinions = {
-		
+
 	}
 	culture_groups = {
 		tibeto_burman_group
-        chinese_group
 	}
 }
 
@@ -40,7 +39,7 @@ REPLACE:zhuang_culture = {
 	tags = { east_asian_gfx }
 
 	opinions = {
-		
+
 	}
 	culture_groups = {
 		thai_group
@@ -73,10 +72,132 @@ REPLACE:tujia_culture = {
 	tags = { east_asian_gfx }
 
 	opinions = {
-		
+
 	}
 	culture_groups = {
 		tibeto_burman_group
 		chinese_group
+	}
+}
+
+REPLACE:korean_culture = {
+	language = korean_language
+
+	color = map_KOR
+
+	tags = { east_asian_gfx }
+
+	opinions = {
+		tamna_culture = kindred
+	}
+}
+
+REPLACE:saigoku_culture = {
+	language = japanese_language
+
+	color = map_JAP
+
+	tags = { japanese_gfx east_asian_gfx }
+
+	culture_groups = {
+		japanese_group
+	}
+
+	opinions = {
+		tougoku_culture = kindred
+		touhoku_culture = kindred
+		kyushu_culture = kindred
+	}
+}
+
+REPLACE:tougoku_culture = {
+	language = japanese_language
+
+	color = map_tougoku
+
+	tags = { japanese_gfx east_asian_gfx }
+
+	culture_groups = {
+		japanese_group
+	}
+
+	opinions = {
+		saigoku_culture = kindred
+		touhoku_culture = kindred
+		kyushu_culture = kindred
+	}
+}
+
+REPLACE:kyushu_culture = {
+	language = japanese_language
+
+	color = map_kyushu
+
+	tags = { japanese_gfx east_asian_gfx }
+
+	culture_groups = {
+		japanese_group
+	}
+
+	opinions = {
+		saigoku_culture = kindred
+		tougoku_culture = kindred
+		touhoku_culture = kindred
+	}
+}
+
+REPLACE:touhoku_culture = {
+	language = japanese_language
+
+	color = map_touhoku
+
+	tags = { japanese_gfx east_asian_gfx }
+	culture_groups = {
+		japanese_group
+	}
+
+	opinions = {
+		saigoku_culture = kindred
+		tougoku_culture = kindred
+		kyushu_culture = kindred
+	}
+}
+
+REPLACE:tamna_culture = {
+	language = korean_language
+
+	color = map_TMN
+
+	tags = { east_asian_gfx }
+
+	opinions = {
+		korean_culture = kindred
+	}
+}
+
+REPLACE:bai_culture = { #https://en.wikipedia.org/wiki/Bai_people
+	language = bai_language
+
+	color = map_bai
+
+	tags = { east_asian_gfx }
+
+	opinions = {
+
+	}
+	culture_groups = {
+		tibeto_burman_group
+	}
+}
+
+REPLACE:she_culture = { #https://en.wikipedia.org/wiki/She_people
+	language = kejia_language
+
+	color = map_she
+
+	tags = { east_asian_gfx }
+
+	opinions = {
+
 	}
 }

--- a/in_game/common/cultures/abm_indian_tibeto_burman_cultures.txt
+++ b/in_game/common/cultures/abm_indian_tibeto_burman_cultures.txt
@@ -1,0 +1,180 @@
+﻿REPLACE:dimasa_culture = { #https://en.wikipedia.org/wiki/Dimasa_people
+	language = brahmaputran_language
+
+	color = map_dimasa
+
+	tags = { indian_gfx }
+	culture_groups = {
+		indian_group
+	}
+
+	opinions = {
+
+	}
+}
+
+REPLACE:bodo_culture = {
+	language = brahmaputran_language
+
+	color = map_bodo
+
+	tags = { indian_gfx }
+	culture_groups = {
+		indian_group
+	}
+
+	opinions = {
+		kamarupi = positive
+	}
+}
+
+REPLACE:garo_culture = {
+	language = brahmaputran_language
+
+	color = map_garo
+
+	tags = { indian_gfx }
+	culture_groups = {
+		indian_group
+	}
+
+	opinions = {
+
+	}
+}
+
+REPLACE:rabha_culture = { #https://en.wikipedia.org/wiki/Rabha_people
+	language = brahmaputran_language
+
+	color = map_rabha
+
+	tags = { indian_gfx }
+	culture_groups = {
+		indian_group
+	}
+
+	opinions = {
+
+	}
+}
+
+REPLACE:deori_culture = { #https://en.wikipedia.org/wiki/Deori_people
+	language = brahmaputran_language
+
+	color = map_deori
+
+	tags = { indian_gfx }
+	culture_groups = {
+		indian_group
+	}
+
+	opinions = {
+
+	}
+}
+
+REPLACE:tiwa_culture = { #https://en.wikipedia.org/wiki/Tiwa_people_(India)
+	language = brahmaputran_language
+
+	color = map_tiwa
+
+	tags = { indian_gfx }
+	culture_groups = {
+		indian_group
+	}
+
+	opinions = {
+
+	}
+}
+
+REPLACE:koch_culture = { #https://en.wikipedia.org/wiki/Koch_people
+	language = brahmaputran_language
+
+	color = map_koch
+
+	tags = { indian_gfx }
+	culture_groups = {
+		indian_group
+	}
+
+	opinions = {
+
+	}
+}
+
+REPLACE:chutia_culture = { #https://en.wikipedia.org/wiki/Chutia_people
+	language = brahmaputran_language
+
+	color = map_chutia
+
+	tags = { indian_gfx }
+	culture_groups = {
+		indian_group
+	}
+
+	opinions = {
+
+	}
+}
+
+REPLACE:tripuri_culture = { #https://en.wikipedia.org/wiki/Tripuri_culture
+	language = brahmaputran_language
+
+	color = map_tripuri
+
+	tags = { indian_gfx }
+	culture_groups = {
+		indian_group
+	}
+
+	opinions = {
+
+	}
+}
+
+REPLACE:karbi_culture = { #https://en.wikipedia.org/wiki/Karbi_people
+	language = meitei_language
+
+	color = map_karbi
+
+	tags = { indian_gfx }
+	culture_groups = {
+		indian_group
+	}
+
+	opinions = {
+
+	}
+}
+
+REPLACE:newar_culture = {
+	language = tibetan_language
+
+	color = map_newar
+
+	tags = { tibetan_gfx east_asian_gfx }
+	culture_groups = {
+		indian_group
+		nepali_group
+	}
+
+	opinions = {
+
+	}
+}
+
+REPLACE:chakma_culture = {
+	language = bengali_language
+
+	color = map_chakma
+
+	tags = { indian_gfx }
+	culture_groups = {
+		indian_group
+	}
+
+	opinions = {
+
+	}
+}

--- a/in_game/common/cultures/abm_scandinavian_cultures.txt
+++ b/in_game/common/cultures/abm_scandinavian_cultures.txt
@@ -1,0 +1,19 @@
+﻿REPLACE:norn_culture = {
+	language = icelandic_dialect
+
+	color = map_norn
+
+	tags = { icelandic_gfx norwegian_gfx western_european_gfx european_gfx }
+
+	opinions = {
+		icelandic = kindred
+		norwegian = kindred
+		norse_gael = positive
+	}
+
+	culture_groups = {
+		scottish_group
+	}
+
+	use_patronym = yes
+}

--- a/in_game/common/cultures/abm_south_east_asia_cultures.txt
+++ b/in_game/common/cultures/abm_south_east_asia_cultures.txt
@@ -1,0 +1,29 @@
+﻿REPLACE:vietnamese_culture = {
+	language = vietnamese_language
+
+	color = map_DAI
+
+	tags = { indochina_gfx east_asian_gfx }
+
+	opinions = {
+
+	}
+	culture_groups = {
+		austroasiatic_group
+	}
+}
+
+REPLACE:muong_culture = {
+	language = vietnamese_language
+
+	color = map_muong
+
+	tags = { indochina_gfx east_asian_gfx }
+
+	opinions = {
+
+	}
+	culture_groups = {
+		austroasiatic_group
+	}
+}

--- a/in_game/common/estate_privileges/ars_belli_confucian_access.txt
+++ b/in_game/common/estate_privileges/ars_belli_confucian_access.txt
@@ -1,0 +1,64 @@
+﻿REPLACE:petty_bureaucracy = { #https://en.wikipedia.org/wiki/Jungin
+	estate = burghers_estate
+
+	potential = {
+		OR = {
+			culture ?= { ars_belli_has_confucian_culture_access = yes }
+			any_international_organizations_member_of = {
+				international_organization_type = international_organization_type:sect
+				international_organization_has_policy = policy:confucianism_policy
+			}
+			has_variable = has_neo_confucianism
+			is_member_of_international_organization = international_organization:middle_kingdom
+		}
+	}
+	allow = {
+		has_imperial_examinations = yes
+	}
+
+	can_revoke = {
+		not = { has_imperial_examinations = yes }
+	}
+
+	country_modifier = {
+		burghers_estate_max_tax = -0.05
+		global_burghers_estate_power = 0.33
+
+		global_burghers_max_literacy = 5
+		country_cabinet_efficiency = 0.1
+		monthly_towards_centralization = societal_value_large_monthly_move
+	}
+}
+
+REPLACE:scholar_officials = { #https://en.wikipedia.org/wiki/Scholar-official
+	estate = nobles_estate
+
+	potential = {
+		OR = {
+			culture ?= { ars_belli_has_confucian_culture_access = yes }
+			any_international_organizations_member_of = {
+				international_organization_type = international_organization_type:sect
+				international_organization_has_policy = policy:confucianism_policy
+			}
+			has_variable = has_neo_confucianism
+			is_member_of_international_organization = international_organization:middle_kingdom
+		}
+	}
+	allow = {
+		has_imperial_examinations = yes
+	}
+
+	can_revoke = {
+		not = { has_imperial_examinations = yes }
+	}
+
+	country_modifier = {
+		nobles_estate_max_tax = -0.05
+		global_nobles_estate_power = 0.33
+
+		global_nobles_max_literacy = 5
+		research_speed_modifier = 0.1
+
+		monthly_towards_innovative = societal_value_large_monthly_move
+	}
+}

--- a/in_game/common/generic_action_ai_lists/conquistador_list.txt
+++ b/in_game/common/generic_action_ai_lists/conquistador_list.txt
@@ -1,0 +1,10 @@
+﻿# Same-name replacement so the Conquistador action is absent from AI action polling.
+
+conquistador_list = {
+	potential = {
+		always = no
+	}
+	actions = {
+		create_conquistador
+	}
+}

--- a/in_game/common/generic_actions/conquistadors.txt
+++ b/in_game/common/generic_actions/conquistadors.txt
@@ -1,0 +1,60 @@
+﻿# Same-name replacement: REPLACE: is not honored by the generic_actions database.
+
+create_conquistador = {
+	type = owncountry
+	show_in_gui_list = no
+
+	ai_tick = never
+	automation_tick = never
+
+	potential = {
+		always = no
+	}
+	ai_prerequisite = {
+		always = no
+	}
+	allow = {
+		always = no
+	}
+
+	# Keep the vanilla price and selection shape so the explicit expansion-view
+	# button still has every field it expects, even though every entry point is gated.
+	should_execute_price = no
+	price = price:recruit_conquistador
+
+	select_trigger = {
+		looking_for_a = character
+		source = actor
+		target_flag = target
+		name = "recruit_conquistador_select_char_title"
+		none_available_msg_key = "create_conquistador_no_characters"
+		column = {
+			data = character_explorer
+		}
+		visible = {
+			always = no
+		}
+	}
+
+	select_trigger = {
+		top_widget = conquistador_character_top
+		looking_for_a = area
+		target_flag = target_1
+		cache_targets = yes
+		name = "recruit_conquistador_select_area_title"
+		none_available_msg_key = "create_conquistador_no_areas"
+		column = {
+			data = name
+		}
+		visible = {
+			always = no
+		}
+	}
+
+	effect = {
+	}
+
+	ai_will_do = {
+		add = -1000
+	}
+}

--- a/in_game/common/government_reforms/ars_belli_no_conquistadors.txt
+++ b/in_game/common/government_reforms/ars_belli_no_conquistadors.txt
@@ -1,0 +1,19 @@
+﻿REPLACE:conquistador_country = {
+	major = yes
+
+	potential = {
+		always = no
+	}
+	allow = {
+		always = no
+	}
+	locked = {
+		is_locked_mechanic = {
+			mechanic = government_reform
+			type = conquistador_country
+		}
+	}
+	country_modifier = {
+	}
+	years = 2
+}

--- a/in_game/common/laws/ars_belli_confucian_access.txt
+++ b/in_game/common/laws/ars_belli_confucian_access.txt
@@ -1,0 +1,62 @@
+﻿REPLACE:imperial_examination_law = {
+	unique = yes
+	law_category = administrative
+	potential = {
+		OR = {
+			culture ?= { ars_belli_has_confucian_culture_access = yes }
+			any_international_organizations_member_of = {
+				international_organization_type = international_organization_type:sect
+				international_organization_has_policy = policy:confucianism_policy
+			}
+			custom_tooltip = {
+				text = has_neo_confucianism_tt
+				has_variable = has_neo_confucianism
+			}
+			AND = {
+				exists = international_organization:middle_kingdom
+				is_member_of_international_organization = international_organization:middle_kingdom
+				NOT = { is_leader_of_international_organization = international_organization:middle_kingdom }
+			}
+		}
+	}
+
+	continue_the_imperial_examination = {
+		on_activate = {
+			if = {
+				limit = {
+					not = { has_variable = year_of_start_of_examination_system }
+				}
+				set_variable = {
+					name = year_of_start_of_examination_system
+					value = current_year
+					days = 8000 #Giving it a expiring date to avoid shaenanigans
+				}
+			}
+		}
+		estate_preferences = {
+			burghers_estate
+			clergy_estate
+			peasants_estate
+		}
+		years = 2
+
+		country_modifier = {
+			government_size = 1
+			country_cabinet_efficiency = 0.05
+		}
+	}
+
+	abolish_imperial_examination = {
+		estate_preferences = {
+			nobles_estate
+		}
+		years = 2
+
+		country_modifier = {
+			global_pop_promotion_speed_modifier = -0.25
+			nobles_estate_target_satisfaction = large_permanent_target_satisfaction
+			monthly_towards_centralization = societal_value_monthly_move
+			hire_advisor_cost_modifier = -0.25
+		}
+	}
+}

--- a/in_game/common/scripted_triggers/ars_belli_confucian_culture_triggers.txt
+++ b/in_game/common/scripted_triggers/ars_belli_confucian_culture_triggers.txt
@@ -1,0 +1,12 @@
+﻿ars_belli_has_confucian_culture_access = {
+	OR = {
+		has_culture_group = culture_group:confucian_group
+		has_culture_group = culture_group:japanese_group
+		this = culture:korean_culture
+		this = culture:tamna_culture
+		this = culture:vietnamese_culture
+		this = culture:muong_culture
+		this = culture:bai_culture
+		this = culture:she_culture
+	}
+}

--- a/in_game/events/00_ars_belli_no_conquistador.txt
+++ b/in_game/events/00_ars_belli_no_conquistador.txt
@@ -1,0 +1,64 @@
+﻿namespace = flavor_cas
+
+# Events use first-definition-wins. A root event file loads before DHE/, so this
+# keeps the Cortes flavor event while preventing its direct start_conquistador bypass.
+flavor_cas.36 = { #Hernan Cortes
+	type = country_event
+	title = flavor_cas.36.title
+	desc = flavor_cas.36.desc
+	outcome = neutral
+	image = "gfx/interface/illustrations/institutions/new_world.dds"
+	fire_only_once = yes
+
+	historical_info = flavor_cas.36.historical_info
+
+	dynamic_historical_event = {
+		tag = CAS
+		from = 1519.1.1
+		to = 1530.1.1
+		monthly_chance = 1
+	}
+
+	trigger = {
+		has_presence_in = region:caribbean_region
+	}
+
+	immediate = {
+		create_character = {
+			first_name = Hernan
+			dynasty = dynasty:cortes_dynasty
+			adm = { 50 70 }
+			dip = { 50 70 }
+			mil = 100
+			birth_date = 1485.12.1
+			birth_location = location:medellin
+			culture = culture:castilian
+			estate = estate_type:nobles_estate
+			script = cas_cortes
+			save_scope_as = target_character
+			create_in_limbo = yes
+		}
+	}
+
+	option = {
+		name = flavor_cas.36.a
+		historical_option = yes
+		scope:target_character = {
+			move_country = root
+			add_random_trait_from_category = general
+			add_character_modifier = {
+				modifier = refuses_to_serve_in_cabinet
+				years = -1
+				mode = add_and_extend
+			}
+		}
+	}
+
+	option = {
+		name = flavor_cas.36.b
+		add_prestige = prestige_mild_penalty
+		hidden_effect = {
+			kill_character_silently = scope:target_character
+		}
+	}
+}

--- a/memory.md
+++ b/memory.md
@@ -127,6 +127,16 @@ Significant changes to siege mechanics and fort limits (documented in `changes.t
 - **`divide = { value = X min = 1 }` is the vanilla divide-by-zero guard** (`script_values\diplomatic_values.txt`), and `max = N` as a sibling of `value`/`multiply` clamps the finished term. Both are worth reaching for whenever an acceptance term divides by another country's income.
 - **Estates and "the bank" are the same thing in EU5's own vocabulary** — `generic_actions\take_bank_loan.txt` defines `take_estate_loan`, whose message log reads "We took a loan from the bank". Expect player reports about "banks" to mean either the estates or a counterparty country; ask which.
 
+### 3k. Culture-group isolation and Confucian compatibility
+- The overlap cleanup uses `REPLACE:` culture entries rather than changing the base culture files. `abm_indian_tibeto_burman_cultures.txt` removes Tibeto-Burman membership from Dimasa, Bodo, Garo, Rabha, Deori, Tiwa, Koch, Chutia, Tripuri, Karbi, Newar and Chakma; Newar retains both Indian and Nepali membership. `abm_east_asia_cultures.txt` makes Yi and Bai Tibeto-Burman only, the four Japanese cultures Japanese only, and Korean, Tamna and She group-less. `abm_south_east_asia_cultures.txt` makes Vietnamese and Muong Austroasiatic only. `abm_scandinavian_cultures.txt` makes Norn Scottish only.
+- `ars_belli_has_confucian_culture_access` is the single compatibility trigger for cultures that keep former Confucian mechanics: the remaining Confucian group, the Japanese group, Korean, Tamna, Vietnamese, Muong, Bai and She. The Confucian School building and advance, Confucian Academy advance, Imperial Examination law, Petty Bureaucracy and Scholar Officials all call this trigger; update the list once here if culture membership changes again.
+- Ars Belli intentionally ships empty same-name replacements for `common\international_organizations\middle_kingdom.txt` and `common\casus_belli\unify_china.txt`. Do not restore the Middle Kingdom or its mandate casus belli while maintaining Confucian compatibility; those removals predate this work and are separate design decisions.
+
+### 3l. Conquistadors removed
+- The Conquistador advance, generic action, AI action list and government reform are all disabled. The generic action and its AI list are **same-name full-file replacements** recorded in `replaced_files.txt`, because `REPLACE:` is proven unreliable for `generic_actions`; the action is gated at player, AI, automation, selection and effect layers.
+- `events\00_ars_belli_no_conquistador.txt` shadows `flavor_cas.36` from the later-loaded `events\dhe\flavor_CAS.txt`. It preserves both choices and Hernán Cortés as a character/general but omits the effect that creates a Conquistador country. Keep this root event ahead of the DHE file rather than copying the entire vanilla flavor file.
+- The replacement reform has no occupation modifier and cannot be selected. This neutralizes the exploit for existing or already queued cases without deleting existing subject countries. The inactive vanilla GUI surface is intentionally left in place; gameplay creation is blocked without maintaining a large GUI override.
+
 ### 4. Economy & Town Setups
 - Custom building setups for different cultures/regions in `in_game\common\town_setups\00_default.txt`.
 - Tweaks to prices and societal values.
@@ -164,7 +174,7 @@ When the base game updates, copy the new vanilla files from `E:\Steam\steamapps\
 
 To identify mod blocks, search for comments starting with `# Ars Belli` or `# MP Rank`.
 
-Last updated: 2026-08-16 (economic support cap; union call to arms; tributary transfer bans; sell/buy location capped at a flat 100 gold in the GUI; mercenary listing removed; art-sale acceptance tightened).
+Last updated: 2026-08-19 (culture-group isolation with preserved Confucian access; Conquistador creation disabled; economic support cap; union call to arms; tributary transfer bans; sell/buy location capped at a flat 100 gold in the GUI; mercenary listing removed; art-sale acceptance tightened).
 
 ## Important Files
 - `README.md`: Basic mod title.

--- a/replaced_files.txt
+++ b/replaced_files.txt
@@ -31,8 +31,10 @@ in_game/common/disasters/decline_of_majapahit.txt
 in_game/common/disasters/decline_of_mali.txt
 in_game/common/disasters/dissolution_of_delhi.txt
 in_game/common/generic_action_ai_lists/crisis_of_the_chinese_dynasty_list.txt
+in_game/common/generic_action_ai_lists/conquistador_list.txt
 in_game/common/generic_action_ai_lists/decline_of_majapahit_list.txt
 in_game/common/generic_action_ai_lists/lordship_of_ireland.txt
+in_game/common/generic_actions/conquistadors.txt
 in_game/common/generic_actions/make_unit_available_for_hire.txt
 in_game/common/generic_actions/red_turban_rebellions.txt
 in_game/common/generic_actions/rise_of_timur.txt


### PR DESCRIPTION
Closes #42

## What

- Isolate the HIGH Nr.4-Nr.6 culture memberships, including Indian/Tibeto-Burman overlaps, the non-Chinese Confucian bridges, and Norn.
- Preserve the six Confucian-gated systems shipped by Ars Belli for the cultures that leave the Confucian group.
- Disable Conquistador creation for players, AI, automation, and the Cortés event while keeping Cortés as a normal general.

## Why

The overlapping culture groups bypass the intended regional separation, while removing Confucian membership outright would also remove unrelated cultural mechanics. Conquistador countries can bypass normal warfare through automatic occupation.

## How

- Use targeted culture replacements and one shared compatibility trigger for Confucian buildings, advances, laws, and estate privileges.
- Use same-name replacements for the generic action and AI list, disable the advance and reform, and shadow only the direct Cortés event bypass.
- Keep Ars Belli's existing removal of the Middle Kingdom and mandate casus belli unchanged.